### PR TITLE
Fix cullface on purification_pc_bottom.json

### DIFF
--- a/common/src/main/resources/assets/shadowedhearts/models/block/purification_pc_bottom.json
+++ b/common/src/main/resources/assets/shadowedhearts/models/block/purification_pc_bottom.json
@@ -38,7 +38,7 @@
 				"south": {"uv": [0.5, 12, 4.5, 12.5], "rotation": 180, "texture": "#texture"},
 				"west": {"uv": [0, 15.5, 0.5, 12.5], "rotation": 270, "texture": "#texture"},
 				"up": {"uv": [4.5, 15.5, 0.5, 12.5], "texture": "#texture"},
-				"down": {"uv": [4.5, 15.5, 0.5, 12.5], "texture": "#texture", "cullface": "down"}
+				"down": {"uv": [4.5, 15.5, 0.5, 12.5], "texture": "#texture"}
 			}
 		}
 	],


### PR DESCRIPTION
The current block causes ground xraying.

Without this fix:
<img width="400" alt="Screenshot_20260204_005642" src="https://github.com/user-attachments/assets/553babab-f056-4144-9bfa-21dc104b8880" />

With this fix:
<img width="400" alt="Screenshot_20260204_005718" src="https://github.com/user-attachments/assets/3b837859-95be-4d0d-8927-147a8f107005" />
