### PR TITLE
Fix Cobblemon Battle Extras Mixins + Support all new tooltips

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     modCompileOnly("maven.modrinth:YL57xq9U:zsoi0dso")
 
     //cobblemon battle extras
-    modCompileOnly("maven.modrinth:2iY8VFqL:xucilwgK")
+    modCompileOnly("maven.modrinth:2iY8VFqL:BBOCqBbU")
     //cobblemon party extras
     modCompileOnly("maven.modrinth:x2wZP9kQ:wxVvkEmX")
 

--- a/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtrasBattleInfoPanelRendererMixin.java
+++ b/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtrasBattleInfoPanelRendererMixin.java
@@ -1,0 +1,116 @@
+package com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras;
+
+import com.cobblemon.mod.common.client.battle.ClientBattlePokemon;
+import com.cobblemon.mod.common.pokemon.Pokemon;
+import com.jayemceekay.shadowedhearts.PokemonAspectUtil;
+import com.jayemceekay.shadowedhearts.ShadowGate;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.mojang.blaze3d.systems.RenderSystem;
+import name.modid.client.BattleInfoPanelRenderer;
+import name.modid.client.LocalBattlePartyTracker;
+import name.modid.client.RevealedBattleInfo;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.resources.ResourceLocation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+
+// Only for >=1.7.41
+// BattleInfoPanel is the panel that appears when hovering over the top right/left Pokémon portraits/life bars
+@Mixin(BattleInfoPanelRenderer.class)
+public class CobblemonBattleExtrasBattleInfoPanelRendererMixin {
+
+    @Unique
+    private static boolean shadowedhearts$shouldMask(String moveId, Pokemon pokemon) {
+        if (moveId == null || pokemon == null) return false;
+        if (ShadowGate.isShadowMoveId(moveId)) return false; // Shadow moves always visible
+
+        // Compute this move's index among non-Shadow moves in move order
+        int nonShadowIndex = 0;
+        int allowed = PokemonAspectUtil.getAllowedVisibleNonShadowMoves(pokemon);
+        for (var mv : pokemon.getMoveSet().getMovesWithNulls()) {
+            if (mv == null) continue;
+            if (ShadowGate.isShadowMoveId(mv.getName())) continue;
+            if (mv.getName().equals(moveId)) {
+                // If this move's position is at or beyond allowed, mask it
+                return nonShadowIndex >= allowed;
+            }
+            nonShadowIndex++;
+        }
+        return false;
+    }
+
+    // Mask Attack name and set white color
+    @ModifyArgs(method = "renderPanel",
+            at = @At(value = "INVOKE", target = "Lname/modid/client/BattleInfoPanelRenderer;drawScaledText(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/Minecraft;Ljava/lang/String;IIIFF)V",
+                    ordinal = 6)
+    )
+    private static void shadowedhearts$maskAttackNameAndColor(Args args, @Local(name = "move") RevealedBattleInfo.PokemonRevealedInfo.MoveInfo move, @Local(ordinal = 1, argsOnly = true) String side, @Local(argsOnly = true) Object battlePokemon) {
+        ClientBattlePokemon bp = (ClientBattlePokemon) battlePokemon;
+        if (side.equals("player")) {
+            Pokemon currentPoke = null;
+            for (Pokemon partyPokemon : LocalBattlePartyTracker.getLocalPartySnapshot()) {
+                if (bp.getUuid().equals(partyPokemon.getUuid())) {
+                    currentPoke = partyPokemon;
+                }
+            }
+            if (shadowedhearts$shouldMask(move.moveId, currentPoke)) {
+                args.set(2, "????");
+                args.set(5, 16777215); // white color
+            }
+        }
+    }
+
+    // Replace type with "shadow-locked" if the move was locked
+    @ModifyArgs(method = "renderPanel",
+            at = @At(value = "INVOKE", target = "Lname/modid/client/BattleInfoPanelRenderer;renderTypeIconScaled(Lnet/minecraft/client/gui/GuiGraphics;IILjava/lang/String;FFI)V")
+    )
+    private static void shadowedhearts$changeTypeToLocked(Args args, @Local(name = "move") RevealedBattleInfo.PokemonRevealedInfo.MoveInfo move, @Local(ordinal = 1, argsOnly = true) String side, @Local(argsOnly = true) Object battlePokemon) {
+        ClientBattlePokemon bp = (ClientBattlePokemon) battlePokemon;
+        if (side.equals("player")) {
+            Pokemon currentPoke = null;
+            for (Pokemon partyPokemon : LocalBattlePartyTracker.getLocalPartySnapshot()) {
+                if (bp.getUuid().equals(partyPokemon.getUuid())) {
+                    currentPoke = partyPokemon;
+                }
+            }
+            if (shadowedhearts$shouldMask(move.moveId, currentPoke)) {
+                args.set(3, "shadow-locked");
+            }
+        }
+    }
+
+    // Render the shadow/locked type icon
+    @Inject(method = "renderTypeIconScaled", at = @At("HEAD"), cancellable = true)
+    private static void shadowedhearts$renderShadowIcon(GuiGraphics gui, int x, int y, String type, float alpha, float brightness, int displaySize, CallbackInfo ci) {
+        ResourceLocation texture = null;
+        boolean customIcon = false;
+        if (type.equals("shadow")) {
+            texture = ResourceLocation.fromNamespaceAndPath("shadowedhearts", "textures/gui/shadow_type.png");
+            customIcon = true;
+        } else if (type.equals("shadow-locked")) {
+            texture = ResourceLocation.fromNamespaceAndPath("shadowedhearts", "textures/gui/disabled_move.png");
+            customIcon = true;
+        }
+
+        if (customIcon) {
+            gui.flush();
+            gui.pose().pushPose();
+            gui.pose().translate(0.0F, 0.0F, 100.0F);
+            RenderSystem.enableBlend();
+            RenderSystem.defaultBlendFunc();
+            float clampedBrightness = Math.max(0.0F, brightness);
+            RenderSystem.setShaderColor(clampedBrightness, clampedBrightness, clampedBrightness, alpha);
+            gui.blit(texture, x, y, displaySize, displaySize, 0.0F, 0.0F, 36, 36, 36, 36);
+            RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+            gui.pose().popPose();
+            gui.flush();
+
+            ci.cancel();
+        }
+    }
+}

--- a/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtrasCustomBattleControllerMixin.java
+++ b/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtrasCustomBattleControllerMixin.java
@@ -81,7 +81,8 @@ public class CobblemonBattleExtrasCustomBattleControllerMixin {
                 moveInfo.shadowedhearts$setMoveType(ElementalTypes.get("shadow-locked"));
                 originalPreviewLines.set(i, null);
             } else {
-                moveInfo.shadowedhearts$setTypeTextureX(0); // This is needed for the custom shadow icon to render correctly
+                if (ShadowGate.isShadowMoveId(moveId))
+                    moveInfo.shadowedhearts$setTypeTextureX(0); // This is needed for the custom shadow icon to render correctly
 
                 originalPreviewLines.set(i, previewLine);
             }

--- a/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtrasCustomBattleControllerMixin.java
+++ b/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtrasCustomBattleControllerMixin.java
@@ -1,0 +1,232 @@
+package com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras;
+
+import com.cobblemon.mod.common.api.moves.MoveTemplate;
+import com.cobblemon.mod.common.api.types.ElementalType;
+import com.cobblemon.mod.common.api.types.ElementalTypes;
+import com.cobblemon.mod.common.pokemon.Pokemon;
+import com.jayemceekay.shadowedhearts.PokemonAspectUtil;
+import com.jayemceekay.shadowedhearts.ShadowGate;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import name.modid.client.CustomBattleController;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Coerce;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.List;
+
+// Only for >=1.7.41
+// CustomBattleController manages the rendering of a few things:
+// * The tooptip that appears when hovering a Pokémon on the "Switch Pokémon" menu.
+// * The rendering of the custom Move Tiles when "enableCustomMoveTiles" is true in the config
+@Mixin(CustomBattleController.class)
+public class CobblemonBattleExtrasCustomBattleControllerMixin {
+
+    @Unique
+    private static boolean shadowedhearts$shouldMask(String m, Pokemon pokemon) {
+        if (m == null || pokemon == null) return false;
+        if (ShadowGate.isShadowMoveId(m)) return false; // Shadow moves always visible
+
+        // Compute this move's index among non-Shadow moves in move order
+        int nonShadowIndex = 0;
+        int allowed = PokemonAspectUtil.getAllowedVisibleNonShadowMoves(pokemon);
+        for (var mv : pokemon.getMoveSet().getMovesWithNulls()) {
+            if (mv == null) continue;
+            if (ShadowGate.isShadowMoveId(mv.getName())) continue;
+            if (mv.getName().equals(m)) {
+                // If this move's position is at or beyond allowed, mask it
+                return nonShadowIndex >= allowed;
+            }
+            nonShadowIndex++;
+        }
+        return false;
+    }
+
+    /*
+    Switch Pokémon tooltip
+     */
+
+    // Mask attack details and change type in Switch Pokémon tooltip
+    @Inject(
+            method = "renderSwitchMovesTooltip",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lname/modid/client/CustomBattleController;renderClassicSwitchMovesTooltip(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/gui/Font;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/List;II)V"
+            )
+    )
+    private static void shadowedhearts$maskAttackDetailsSwitchMenu(CallbackInfo ci, @Local(name = "pokemon") Object pokemon, @Local(name = "moveInfos") List<?> moveInfos, @Local(name = "movePreviewLines") LocalRef<List<Component>> movePreviewLines) {
+        List<Component> originalPreviewLines = movePreviewLines.get();
+
+        for (int i = 0; i < moveInfos.size(); i++) {
+            CobblemonBattleExtrasMoveDisplayInfoAccessor moveInfo = (CobblemonBattleExtrasMoveDisplayInfoAccessor) moveInfos.get(i);
+            Component previewLine = originalPreviewLines.get(i);
+
+            String moveId = moveInfo.shadowedhearts$getRawName();
+
+            if (shadowedhearts$shouldMask(moveId, (Pokemon) pokemon)) {
+                moveInfo.shadowedhearts$setDisplayName("????");
+                moveInfo.shadowedhearts$setPpText("??/??");
+                moveInfo.shadowedhearts$setPpColor(16777215); // White
+                moveInfo.shadowedhearts$setTypeTextureX(0); // This is needed for the custom shadow icon to render correctly
+                moveInfo.shadowedhearts$setMoveType(ElementalTypes.get("shadow-locked"));
+                originalPreviewLines.set(i, null);
+            } else {
+                moveInfo.shadowedhearts$setTypeTextureX(0); // This is needed for the custom shadow icon to render correctly
+
+                originalPreviewLines.set(i, previewLine);
+            }
+        }
+    }
+
+    // Render Shadow icon in Switch Pokémon tooltip
+    @WrapOperation(method = "renderClassicSwitchMovesTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphics;blit(Lnet/minecraft/resources/ResourceLocation;IIIIFFIIII)V"))
+    private static void shadowedhearts$renderShadowIconSwitchMenu(GuiGraphics instance, ResourceLocation resourceLocation, int x, int y, int renderSizeX, int renderSizeY, float texU, float texV, int uvWidth, int uvHeight, int imgSizeX, int imgSizeY, Operation<Void> original, @Local(name = "moveInfos") List<?> moveInfos, @Local(name = "i") int index) {
+        CobblemonBattleExtrasMoveDisplayInfoAccessor moveInfo = (CobblemonBattleExtrasMoveDisplayInfoAccessor) moveInfos.get(index);
+        ElementalType type = (ElementalType) moveInfo.shadowedhearts$getMoveType();
+
+        // The original size is the wide of a spritesheet containing all type icons.
+        // If we are to render the shadow icon, we need to change it to the same as "imgSizeX", which is the vertical size of the image
+        int size = imgSizeX;
+        if (type.equals(ElementalTypes.get("shadow"))) {
+            resourceLocation = ResourceLocation.fromNamespaceAndPath("shadowedhearts", "textures/gui/shadow_type.png");
+            size = imgSizeY;
+        } else if (type.equals(ElementalTypes.get("shadow-locked"))) {
+            resourceLocation = ResourceLocation.fromNamespaceAndPath("shadowedhearts", "textures/gui/disabled_move.png");
+            size = imgSizeY;
+        }
+
+        original.call(instance, resourceLocation, x, y, renderSizeX, renderSizeY, texU, texV, uvWidth, uvHeight, size, imgSizeY);
+    }
+
+    /*
+    Custom move tiles
+     */
+
+    // Modify MoveTileVisualData for Custom Tiles
+    @WrapOperation(method = "renderCustomMoveTiles", at = @At(value = "INVOKE", target = "Lname/modid/client/CustomBattleController;resolveMoveTileVisualData(Ljava/lang/Object;)Lname/modid/client/CustomBattleController$MoveTileVisualData;"))
+    private static @Coerce Object shadowedhearts$shadowMoveTileVisualData(Object tile, Operation<Object> original) {
+        Object originalObj = original.call(tile);
+
+        String moveName = "";
+        Field moveTemplateField = shadowedhearts$findFieldInHierarchy(tile.getClass(), "moveTemplate");
+        try {
+            Object moveTemplateObject = null;
+            if (moveTemplateField != null) {
+                moveTemplateField.setAccessible(true);
+                moveTemplateObject = moveTemplateField.get(tile);
+            }
+            if (moveTemplateObject instanceof MoveTemplate moveTemplate) {
+                moveTemplateField.setAccessible(true);
+                moveName = moveTemplate.getName();
+            }
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+
+        Object pokemonObject = null;
+        Field pokemonField = shadowedhearts$findFieldInHierarchy(tile.getClass(), "pokemon");
+        if (pokemonField != null) {
+            pokemonField.setAccessible(true);
+            try {
+                pokemonObject = pokemonField.get(tile);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        try {
+            if (shadowedhearts$shouldMask(moveName, (Pokemon) pokemonObject)) {
+                CobblemonBattleExtrasMoveTileVisualDataAccessor tileVisualDataExt = (CobblemonBattleExtrasMoveTileVisualDataAccessor) originalObj;
+
+                // Create a new instance with the new data
+                Class<?> clazz = Class.forName("name.modid.client.CustomBattleController$MoveTileVisualData");
+                Constructor<?> ctor = clazz.getDeclaredConstructor(
+                        String.class, int.class, int.class, boolean.class, String.class, int.class, String.class, int.class, int.class
+                );
+                ctor.setAccessible(true);
+
+                return ctor.newInstance(
+                        "????", // moveName
+                        tileVisualDataExt.shadowedhearts$getCurrentPp(),
+                        tileVisualDataExt.shadowedhearts$getMaxPp(),
+                        false, // selectable
+                        "???", // categoryKey
+                        0, // power
+                        "shadow-locked", //moveTypeName
+                        522133503, // typeColor; Same color from MixinMoveSlotWidget, but in int RGBA format
+                        0 // typeTextureMultiplier
+                );
+            }
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+
+        return originalObj;
+    }
+
+    // Copied from CustomBattleController
+    @Unique
+    private static Field shadowedhearts$findFieldInHierarchy(Class<?> startClass, String fieldName) {
+        for (Class<?> currentClass = startClass; currentClass != null && currentClass != Object.class; currentClass = currentClass.getSuperclass()) {
+            try {
+                return currentClass.getDeclaredField(fieldName);
+            } catch (NoSuchFieldException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        return null;
+    }
+
+    // Render shadow icon in Custom Tiles
+    @WrapOperation(method = "renderCustomMoveTile", at = @At(value = "INVOKE", target = "Lname/modid/client/CustomBattleController;renderMoveTypeBadgeIcon(Lnet/minecraft/client/gui/GuiGraphics;Lname/modid/client/CustomBattleController$MoveTileVisualData;IIF)V"))
+    private static void shadowedhearts$renderShadowIcon(GuiGraphics graphics, @Coerce Object data, int x, int y, float opacity, Operation<Void> original) {
+        CobblemonBattleExtrasMoveTileVisualDataAccessor tileVisualDataExt = (CobblemonBattleExtrasMoveTileVisualDataAccessor) data;
+        if (tileVisualDataExt.shadowedhearts$getMoveTypeName().equals("shadow")) {
+            ResourceLocation texture = ResourceLocation.fromNamespaceAndPath("shadowedhearts", "textures/gui/shadow_type.png");
+            graphics.blit(texture, x, y, 12, 12, 0.0F, 0.0F, 36, 36, 36, 36);
+            return;
+        } else if (tileVisualDataExt.shadowedhearts$getMoveTypeName().equals("shadow-locked")) {
+            ResourceLocation texture = ResourceLocation.fromNamespaceAndPath("shadowedhearts", "textures/gui/disabled_move.png");
+            graphics.blit(texture, x, y, 12, 12, 0.0F, 0.0F, 36, 36, 36, 36);
+            return;
+        }
+        original.call(graphics, data, x, y, opacity);
+    }
+
+    // Create custom CategoryChipStyle with ??? data.
+    // Both "Object" are CategoryChipStyle.
+    @WrapOperation(method = "renderCustomMoveTile", at = @At(value = "INVOKE", target = "Lname/modid/client/CustomBattleController;resolveMoveCategoryChipStyle(Ljava/lang/String;)Lname/modid/client/CustomBattleController$CategoryChipStyle;"))
+    private static @Coerce Object shadowedhearts$resolveChipStyle(String categoryKey, Operation<Object> original) {
+        try {
+            Class<?> clazz = Class.forName("name.modid.client.CustomBattleController$CategoryChipStyle");
+            Constructor<?> ctor = clazz.getDeclaredConstructor(
+                    String.class, int.class, int.class, int.class, int.class, int.class
+            );
+            ctor.setAccessible(true);
+
+            // Same values as STA, copied from resolveMoveCategoryChipStyle
+            return ctor.newInstance(
+                    "???", // label
+                    16, // width
+                    -8683114, // bgTop
+                    -11907231, // bgBottom
+                    -3814695, // border
+                    -1 // text
+            );
+        } catch (Throwable e) {
+            //throw new RuntimeException(e);
+            return original.call(categoryKey);
+        }
+    }
+}

--- a/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtrasCustomTooltipRendererMixin.java
+++ b/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtrasCustomTooltipRendererMixin.java
@@ -1,0 +1,73 @@
+package com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras;
+
+import com.cobblemon.mod.common.api.types.ElementalType;
+import com.cobblemon.mod.common.api.types.ElementalTypes;
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.sugar.Local;
+import name.modid.client.CustomTooltipRenderer;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.resources.ResourceLocation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+
+// Only for >=1.7.41
+// CustomTooltipRenderer renders the attack tooltip when selecting it
+@Mixin(CustomTooltipRenderer.class)
+public class CobblemonBattleExtrasCustomTooltipRendererMixin {
+
+    // Render shadow icon
+    @WrapMethod(method = "renderTypeIcon")
+    private static void shadowedhearts$renderTypeIcon(GuiGraphics graphics, int x, int y, ElementalType type, Operation<Void> original) {
+        if (type.equals(ElementalTypes.get("shadow"))) {
+            ResourceLocation texture = ResourceLocation.fromNamespaceAndPath("shadowedhearts", "textures/gui/shadow_type_small.png");
+            int ICON_SIZE = 18;
+            int RENDER_SIZE = 9;
+            graphics.blit(texture, x, y, RENDER_SIZE, RENDER_SIZE, 0.0F, 0.0F, ICON_SIZE, ICON_SIZE, ICON_SIZE, ICON_SIZE);
+            return;
+        }
+        original.call(graphics, x, y, type);
+    }
+
+    // Render shadow icon
+    @WrapMethod(method = "renderTypeIconLarge")
+    private static void shadowedhearts$renderTypeIconLarge(GuiGraphics graphics, int x, int y, ElementalType type, Operation<Void> original) {
+        if (type.equals(ElementalTypes.get("shadow"))) {
+            ResourceLocation texture = ResourceLocation.fromNamespaceAndPath("shadowedhearts", "textures/gui/shadow_type.png");
+            int iconSize = 36;
+            int renderSize = 18;
+            graphics.blit(texture, x, y, renderSize, renderSize, 0.0F, 0.0F, iconSize, iconSize, iconSize, iconSize);
+            return;
+        }
+        original.call(graphics, x, y, type);
+    }
+
+    // Render shadow icon
+    @WrapMethod(method = "renderTypeIconSmall")
+    private static void shadowedhearts$renderTypeIconSmall(GuiGraphics graphics, int x, int y, ElementalType type, Operation<Void> original) {
+        if (type.equals(ElementalTypes.get("shadow"))) {
+            ResourceLocation texture = ResourceLocation.fromNamespaceAndPath("shadowedhearts", "textures/gui/shadow_type_small.png");
+            int ICON_SIZE = 18;
+            int RENDER_SIZE = 6;
+            graphics.blit(texture, x, y, RENDER_SIZE, RENDER_SIZE, 0.0F, 0.0F, ICON_SIZE, ICON_SIZE, ICON_SIZE, ICON_SIZE);
+            return;
+        }
+        original.call(graphics, x, y, type);
+    }
+
+    // Move the PP text a bit if the type is Shadow so it doesn't overlap with the bright area of the image
+    @ModifyArgs(method = "renderClassicMoveTileForegroundOverlay",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lname/modid/client/CustomTooltipRenderer;drawScaledTextRightAligned(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/gui/Font;Ljava/lang/String;IIIF)V"
+            ))
+    private static void shadowedhearts$movePPText(Args args, @Local(argsOnly = true) ElementalType type) {
+        if (type.equals(ElementalTypes.get("shadow"))) {
+            int x = args.get(3);
+            args.set(3, x + 10);
+        }
+    }
+
+}

--- a/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtrasMoveDisplayInfoAccessor.java
+++ b/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtrasMoveDisplayInfoAccessor.java
@@ -1,0 +1,38 @@
+package com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(targets = "name.modid.client.CustomBattleController$MoveDisplayInfo")
+public interface CobblemonBattleExtrasMoveDisplayInfoAccessor {
+
+    @Accessor("rawName")
+    String shadowedhearts$getRawName();
+    @Accessor("rawName")
+    void shadowedhearts$setRawName(String rawName);
+
+    @Accessor("displayName")
+    String shadowedhearts$getDisplayName();
+    @Accessor("displayName")
+    void shadowedhearts$setDisplayName(String displayName);
+
+    @Accessor("ppText")
+    String shadowedhearts$getPpText();
+    @Accessor("ppText")
+    void shadowedhearts$setPpText(String ppText);
+
+    @Accessor("ppColor")
+    int shadowedhearts$getPpColor();
+    @Accessor("ppColor")
+    void shadowedhearts$setPpColor(int ppColor);
+
+    @Accessor("typeTextureX")
+    int shadowedhearts$getTypeTextureX();
+    @Accessor("typeTextureX")
+    void shadowedhearts$setTypeTextureX(int typeTextureX);
+
+    @Accessor("moveType")
+    Object shadowedhearts$getMoveType();
+    @Accessor("moveType")
+    void shadowedhearts$setMoveType(Object moveType);
+}

--- a/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtrasMoveTileVisualDataAccessor.java
+++ b/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtrasMoveTileVisualDataAccessor.java
@@ -1,0 +1,35 @@
+package com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(targets = "name.modid.client.CustomBattleController$MoveTileVisualData")
+public interface CobblemonBattleExtrasMoveTileVisualDataAccessor {
+
+    @Accessor("moveName")
+    String shadowedhearts$getMoveName();
+
+    @Accessor("currentPp")
+    int shadowedhearts$getCurrentPp();
+
+    @Accessor("maxPp")
+    int shadowedhearts$getMaxPp();
+
+    @Accessor("selectable")
+    boolean shadowedhearts$getSelectable();
+
+    @Accessor("categoryKey")
+    String shadowedhearts$getCategoryKey();
+
+    @Accessor("power")
+    int shadowedhearts$getPower();
+
+    @Accessor("moveTypeName")
+    String shadowedhearts$getMoveTypeName();
+
+    @Accessor("typeColor")
+    int shadowedhearts$getTypeColor();
+
+    @Accessor("typeTextureMultiplier")
+    int shadowedhearts$getTypeTextureMultiplier();
+}

--- a/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtrasPartySideRendererMixin.java
+++ b/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtrasPartySideRendererMixin.java
@@ -1,0 +1,89 @@
+package com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras;
+
+import com.cobblemon.mod.common.api.moves.Move;
+import com.cobblemon.mod.common.pokemon.Pokemon;
+import com.jayemceekay.shadowedhearts.PokemonAspectUtil;
+import com.jayemceekay.shadowedhearts.ShadowGate;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import name.modid.client.PartyInfoSideRenderer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+
+// Only for >=1.7.41
+// PartyInfoSideRenderer renders the left and right side Pokémon party bars
+// The Mixin only changes the details from the tooltip
+@Mixin(value = PartyInfoSideRenderer.class, remap = false)
+public class CobblemonBattleExtrasPartySideRendererMixin {
+
+    @Unique
+    private static boolean shadowedhearts$shouldMask(Move m, Pokemon pokemon) {
+        if (m == null || pokemon == null) return false;
+        if (ShadowGate.isShadowMoveId(m.getName())) return false; // Shadow moves always visible
+
+        // Compute this move's index among non-Shadow moves in move order
+        int nonShadowIndex = 0;
+        int allowed = PokemonAspectUtil.getAllowedVisibleNonShadowMoves(pokemon);
+        for (var mv : pokemon.getMoveSet().getMovesWithNulls()) {
+            if (mv == null) continue;
+            if (ShadowGate.isShadowMoveId(mv.getName())) continue;
+            if (mv == m) {
+                // If this move's position is at or beyond allowed, mask it
+                return nonShadowIndex >= allowed;
+            }
+            nonShadowIndex++;
+        }
+        return false;
+    }
+
+    // Mask attack name
+    @WrapOperation(
+            method = "renderTooltip",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lname/modid/client/PartyInfoSideRenderer;safeMoveDisplayName(Lcom/cobblemon/mod/common/api/moves/Move;)Ljava/lang/String;"
+            )
+    )
+    private static String shadowedhearts$maskName(Move move, Operation<String> original, @Local(argsOnly = true) Pokemon pokemon) {
+        if (shadowedhearts$shouldMask(move, pokemon)) {
+            return "????";
+        }
+        return original.call(move);
+    }
+
+    // Mask attack color. Returning null makes it white
+    @WrapOperation(
+            method = "renderTooltip",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lname/modid/client/BattleMessageColorizer;getTypeColorByName(Ljava/lang/String;)Ljava/lang/Integer;"
+            )
+    )
+    private static Integer shadowedhearts$maskColorName(String typeName, Operation<Integer> original, @Local(argsOnly = true) Pokemon pokemon, @Local(name = "move") Move move) {
+        if (shadowedhearts$shouldMask(move, pokemon)) {
+            return null;
+        }
+        return original.call(typeName);
+    }
+
+    // Mask PP text
+    // 8th call of drawScaledText
+    @ModifyArgs(
+            method = "renderTooltip",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lname/modid/client/PartyInfoSideRenderer;drawScaledText(Lnet/minecraft/client/gui/GuiGraphics;Lnet/minecraft/client/gui/Font;Ljava/lang/String;IIIFZ)V",
+                    ordinal = 7
+            )
+    )
+    private static void shadowedhearts$maskCurrentPP(Args args, @Local(name = "move") Move move, @Local(argsOnly = true) Pokemon pokemon) {
+        if (shadowedhearts$shouldMask(move, pokemon)) {
+            args.set(2, "??/??");
+        }
+    }
+}

--- a/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtrasPartySideRendererMixin.java
+++ b/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtrasPartySideRendererMixin.java
@@ -18,7 +18,7 @@ import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 // Only for >=1.7.41
 // PartyInfoSideRenderer renders the left and right side Pokémon party bars
 // The Mixin only changes the details from the tooltip
-@Mixin(value = PartyInfoSideRenderer.class, remap = false)
+@Mixin(PartyInfoSideRenderer.class)
 public class CobblemonBattleExtrasPartySideRendererMixin {
 
     @Unique

--- a/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtrasTypeChartMixin.java
+++ b/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtrasTypeChartMixin.java
@@ -1,0 +1,47 @@
+package com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras;
+
+import com.cobblemon.mod.common.api.moves.MoveTemplate;
+import com.cobblemon.mod.common.api.types.ElementalType;
+import com.jayemceekay.shadowedhearts.config.IShadowConfig;
+import com.jayemceekay.shadowedhearts.config.ShadowedHeartsConfigs;
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import name.modid.client.TypeChart;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+// Only for >=1.7.41
+// TypeChart is used to calculate effectiveness to display texts in some custom tooltips
+// The Mixin only modifies the methods so Shadow moves always display a x2 (if enabled in config)
+// TODO: This should check if the opposing Pokémon is a Shadow Pokémon too, but I don't think there is a way to do it here
+@Mixin(TypeChart.class)
+public abstract class CobblemonBattleExtrasTypeChartMixin {
+
+    @Unique
+    private static float shadowedhearts$getTypeMultiplier() {
+        IShadowConfig cfg = ShadowedHeartsConfigs.getInstance().getShadowConfig();
+        if (cfg.superEffectiveShadowMovesEnabled()) {
+            return 2.0F;
+        }
+        return 1.0F;
+    }
+
+    @WrapMethod(method = "getEffectiveness", remap = false)
+    private static float shadowedhearts$getEffectiveness(MoveTemplate move, ElementalType defenderType1, ElementalType defenderType2, Operation<Float> original) {
+        if (move == null) {
+            return 1.0F;
+        } else {
+            String moveType = move.getElementalType().getName().toLowerCase();
+            if (moveType.equals("shadow"))
+                return shadowedhearts$getTypeMultiplier();
+            return original.call(move, defenderType1, defenderType2);
+        }
+    }
+
+    @WrapMethod(method = "getEffectivenessAgainstTypes", remap = false)
+    private static float shadowedhearts$getEffectivenessAgainstTypes(String moveType, String defenderType1, String defenderType2, Operation<Float> original) {
+        if (moveType.equals("shadow"))
+            return shadowedhearts$getTypeMultiplier();
+        return original.call(moveType, defenderType1, defenderType2);
+    }
+}

--- a/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtras_1_7_25to40_NewMoveTileTooltipMixin.java
+++ b/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtras_1_7_25to40_NewMoveTileTooltipMixin.java
@@ -1,0 +1,40 @@
+package com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras;
+
+import com.cobblemon.mod.common.battles.InBattleMove;
+import com.cobblemon.mod.common.client.gui.battle.subscreen.BattleMoveSelection;
+import com.jayemceekay.shadowedhearts.ShadowGate;
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import net.minecraft.client.gui.GuiGraphics;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+
+@Pseudo
+@Mixin(value = BattleMoveSelection.MoveTile.class, remap = false)
+public abstract class CobblemonBattleExtras_1_7_25to40_NewMoveTileTooltipMixin {
+
+    @WrapMethod(
+            method = "renderTooltipAtPosition"
+    )
+    private void shadowedhearts$cancelShadowTooltip(
+            GuiGraphics context, int tooltipX, int tooltipY, int anchorBottomY, Operation<Void> original
+    ) {
+        BattleMoveSelection.MoveTile self = (BattleMoveSelection.MoveTile) (Object) this;
+
+        if (shadowedhearts$shouldMaskTooltip(self)) {
+            // Cancel the call to prevent the tooltip from rendering
+            return;
+        }
+        original.call(context, tooltipX, tooltipY, anchorBottomY);
+    }
+
+    private static boolean shadowedhearts$shouldMaskTooltip(BattleMoveSelection.MoveTile self) {
+        InBattleMove m = self.getMove();
+        var pokemon = self.getPokemon();
+        if (m == null || pokemon == null) return false;
+
+        return m.getDisabled()
+                && ShadowGate.isShadowLockedClient(pokemon)
+                && !ShadowGate.isShadowMoveId(m.getId());
+    }
+}

--- a/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtras_1_7_41_NewMoveTileTooltipMixin.java
+++ b/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtras_1_7_41_NewMoveTileTooltipMixin.java
@@ -8,6 +8,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import net.minecraft.client.gui.GuiGraphics;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.Unique;
 
 @Pseudo
 @Mixin(value = BattleMoveSelection.MoveTile.class, remap = false)
@@ -28,6 +29,7 @@ public abstract class CobblemonBattleExtras_1_7_41_NewMoveTileTooltipMixin {
         original.call(context, tooltipX, tooltipY, anchorBottomY, tileBounds);
     }
 
+    @Unique
     private static boolean shadowedhearts$shouldMaskTooltip(BattleMoveSelection.MoveTile self) {
         InBattleMove m = self.getMove();
         var pokemon = self.getPokemon();

--- a/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtras_1_7_41_NewMoveTileTooltipMixin.java
+++ b/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtras_1_7_41_NewMoveTileTooltipMixin.java
@@ -11,13 +11,13 @@ import org.spongepowered.asm.mixin.Pseudo;
 
 @Pseudo
 @Mixin(value = BattleMoveSelection.MoveTile.class, remap = false)
-public abstract class CobblemonBattleExtrasNewMoveTileTooltipMixin {
+public abstract class CobblemonBattleExtras_1_7_41_NewMoveTileTooltipMixin {
 
     @WrapMethod(
             method = "renderTooltipAtPosition"
     )
     private void shadowedhearts$cancelShadowTooltip(
-            GuiGraphics context, int tooltipX, int tooltipY, int anchorBottomY, Operation<Void> original
+            GuiGraphics context, int tooltipX, int tooltipY, int anchorBottomY, int[] tileBounds, Operation<Void> original
     ) {
         BattleMoveSelection.MoveTile self = (BattleMoveSelection.MoveTile) (Object) this;
 
@@ -25,7 +25,7 @@ public abstract class CobblemonBattleExtrasNewMoveTileTooltipMixin {
             // Cancel the call to prevent the tooltip from rendering
             return;
         }
-        original.call(context, tooltipX, tooltipY, anchorBottomY);
+        original.call(context, tooltipX, tooltipY, anchorBottomY, tileBounds);
     }
 
     private static boolean shadowedhearts$shouldMaskTooltip(BattleMoveSelection.MoveTile self) {

--- a/common/src/main/resources/shadowedhearts.mixins.json
+++ b/common/src/main/resources/shadowedhearts.mixins.json
@@ -28,7 +28,8 @@
     "RenderTargetAccessor",
     "SummaryAccessor",
     "cobblemonbattleextras.CobblemonBattleExtras_1_7_24_MoveTileTooltipMixin",
-    "cobblemonbattleextras.CobblemonBattleExtrasNewMoveTileTooltipMixin",
+    "cobblemonbattleextras.CobblemonBattleExtras_1_7_25to40_NewMoveTileTooltipMixin",
+    "cobblemonbattleextras.CobblemonBattleExtras_1_7_41_NewMoveTileTooltipMixin",
     "cobblemonpartyextras.MixinCobblemonPartyExtrasSummaryUIMixin"
   ],
   "mixins": [

--- a/common/src/main/resources/shadowedhearts.mixins.json
+++ b/common/src/main/resources/shadowedhearts.mixins.json
@@ -30,6 +30,13 @@
     "cobblemonbattleextras.CobblemonBattleExtras_1_7_24_MoveTileTooltipMixin",
     "cobblemonbattleextras.CobblemonBattleExtras_1_7_25to40_NewMoveTileTooltipMixin",
     "cobblemonbattleextras.CobblemonBattleExtras_1_7_41_NewMoveTileTooltipMixin",
+    "cobblemonbattleextras.CobblemonBattleExtrasBattleInfoPanelRendererMixin",
+    "cobblemonbattleextras.CobblemonBattleExtrasCustomBattleControllerMixin",
+    "cobblemonbattleextras.CobblemonBattleExtrasCustomTooltipRendererMixin",
+    "cobblemonbattleextras.CobblemonBattleExtrasMoveDisplayInfoAccessor",
+    "cobblemonbattleextras.CobblemonBattleExtrasMoveTileVisualDataAccessor",
+    "cobblemonbattleextras.CobblemonBattleExtrasPartySideRendererMixin",
+    "cobblemonbattleextras.CobblemonBattleExtrasTypeChartMixin",
     "cobblemonpartyextras.MixinCobblemonPartyExtrasSummaryUIMixin"
   ],
   "mixins": [

--- a/fabric/src/main/java/com/jayemceekay/shadowedhearts/mixin/ShadowedHeartsMixinConfigPlugin.java
+++ b/fabric/src/main/java/com/jayemceekay/shadowedhearts/mixin/ShadowedHeartsMixinConfigPlugin.java
@@ -32,13 +32,24 @@ public class ShadowedHeartsMixinConfigPlugin implements IMixinConfigPlugin {
                     yield false;
                 }
             }
-            case "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtrasNewMoveTileTooltipMixin" -> {
+            case "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtras_1_7_25to40_NewMoveTileTooltipMixin" -> {
                 if( !Platform.isModLoaded("cobblemon-battle-extras"))
                     yield false;
                 var mod = Platform.getMod("cobblemon-battle-extras");
                 if (mod == null) yield false;
                 try {
-                    yield VersionPredicate.parse(">=1.7.25").test(Version.parse(mod.getVersion()));
+                    yield VersionPredicate.parse(">=1.7.25 <=1.7.40").test(Version.parse(mod.getVersion()));
+                } catch (VersionParsingException e) {
+                    yield false;
+                }
+            }
+            case "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtras_1_7_41_NewMoveTileTooltipMixin" -> {
+                if( !Platform.isModLoaded("cobblemon-battle-extras"))
+                    yield false;
+                var mod = Platform.getMod("cobblemon-battle-extras");
+                if (mod == null) yield false;
+                try {
+                    yield VersionPredicate.parse(">=1.7.41").test(Version.parse(mod.getVersion()));
                 } catch (VersionParsingException e) {
                     yield false;
                 }

--- a/fabric/src/main/java/com/jayemceekay/shadowedhearts/mixin/ShadowedHeartsMixinConfigPlugin.java
+++ b/fabric/src/main/java/com/jayemceekay/shadowedhearts/mixin/ShadowedHeartsMixinConfigPlugin.java
@@ -43,7 +43,14 @@ public class ShadowedHeartsMixinConfigPlugin implements IMixinConfigPlugin {
                     yield false;
                 }
             }
-            case "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtras_1_7_41_NewMoveTileTooltipMixin" -> {
+            case "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtras_1_7_41_NewMoveTileTooltipMixin",
+                 "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtrasBattleInfoPanelRendererMixin",
+                 "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtrasCustomBattleControllerMixin",
+                 "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtrasCustomTooltipRendererMixin",
+                 "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtrasMoveDisplayInfoAccessor",
+                 "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtrasMoveTileVisualDataAccessor",
+                 "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtrasPartySideRendererMixin",
+                 "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtrasTypeChartMixin" -> {
                 if( !Platform.isModLoaded("cobblemon-battle-extras"))
                     yield false;
                 var mod = Platform.getMod("cobblemon-battle-extras");

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -110,7 +110,7 @@ dependencies {
     //modRuntimeOnly("maven.modrinth:QyvWSZ5S:E7K9ZMD2")
 
     //cobblemon battle extras
-    modImplementation("maven.modrinth:2iY8VFqL:xucilwgK")
+    modImplementation("maven.modrinth:2iY8VFqL:BBOCqBbU")
 
     //cobblemon party extras
     modImplementation("maven.modrinth:x2wZP9kQ:wxVvkEmX")

--- a/neoforge/src/main/java/com/jayemceekay/shadowedhearts/mixin/ShadowedHeartsMixinConfigPlugin.java
+++ b/neoforge/src/main/java/com/jayemceekay/shadowedhearts/mixin/ShadowedHeartsMixinConfigPlugin.java
@@ -32,11 +32,21 @@ public class ShadowedHeartsMixinConfigPlugin implements IMixinConfigPlugin {
                     yield false;
                 }
             }
-            case "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtrasNewMoveTileTooltipMixin" -> {
+            case "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtras_1_7_25to40_NewMoveTileTooltipMixin" -> {
                 var mod = FMLLoader.getLoadingModList().getModFileById("cobblemon_battle_extras");
                 if (mod == null) yield false;
                 try {
-                    yield VersionRange.createFromVersionSpec("[1.7.25,)")
+                    yield VersionRange.createFromVersionSpec("[1.7.25,1.7.40]")
+                            .containsVersion(new DefaultArtifactVersion(mod.versionString()));
+                } catch (Exception e) {
+                    yield false;
+                }
+            }
+            case "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtras_1_7_41_NewMoveTileTooltipMixin" -> {
+                var mod = FMLLoader.getLoadingModList().getModFileById("cobblemon_battle_extras");
+                if (mod == null) yield false;
+                try {
+                    yield VersionRange.createFromVersionSpec("[1.7.41,)")
                             .containsVersion(new DefaultArtifactVersion(mod.versionString()));
                 } catch (Exception e) {
                     yield false;

--- a/neoforge/src/main/java/com/jayemceekay/shadowedhearts/mixin/ShadowedHeartsMixinConfigPlugin.java
+++ b/neoforge/src/main/java/com/jayemceekay/shadowedhearts/mixin/ShadowedHeartsMixinConfigPlugin.java
@@ -42,7 +42,14 @@ public class ShadowedHeartsMixinConfigPlugin implements IMixinConfigPlugin {
                     yield false;
                 }
             }
-            case "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtras_1_7_41_NewMoveTileTooltipMixin" -> {
+            case "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtras_1_7_41_NewMoveTileTooltipMixin",
+                 "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtrasBattleInfoPanelRendererMixin",
+                 "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtrasCustomBattleControllerMixin",
+                 "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtrasCustomTooltipRendererMixin",
+                 "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtrasMoveDisplayInfoAccessor",
+                 "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtrasMoveTileVisualDataAccessor",
+                 "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtrasPartySideRendererMixin",
+                 "com.jayemceekay.shadowedhearts.mixin.cobblemonbattleextras.CobblemonBattleExtrasTypeChartMixin" -> {
                 var mod = FMLLoader.getLoadingModList().getModFileById("cobblemon_battle_extras");
                 if (mod == null) yield false;
                 try {


### PR DESCRIPTION
Hi, with the latest version of CobblemonBattleExtras (1.7.41), the Mixins are broken and crash the game. There are also a few new tooltips that are not handled by ShadowedHearts.

Here is the list of changes, all of them only affect compatibility with CobblemonBattleExtras 1.7.41:

Mixin fixes:

- Renamed `CobblemonBattleExtrasNewMoveTileTooltipMixin` to `CobblemonBattleExtras_1_7_25to40_NewMoveTileTooltipMixin`. This one is only applied with CobblemonBattleExtras >=1.7.25 <=1.7.40.
- Added `CobblemonBattleExtras_1_7_41_NewMoveTileTooltipMixin`. This is the new one applied with CobblemonBattleExtras >=1.7.41.

Add new CobblemonBattleExtras Mixins to fully support all 1.7.41 tooltips:

- `BattleInfoPanelRendererMixin`: Handles the top panel info that appears when hovering over the Pokémon bars.
- `CustomBattleControllerMixin`: Handles the tooltip that appears when hovering Pokémon in the "Switch Pokémon" menu, and shadows the "CustomTiles" move info.
- `CustomTooltipRendererMixin`: Handles move tooltips.
- `MoveDisplayInfoAccessor`: Helper interface to access data from the private `CustomBattleController$MoveDisplayInfo` class.
- `MoveTileVisualDataAccessor`: Helper interface to access data from the private `CustomBattleController$MoveTileVisualData` class.
- `PartySideRendererMixin`: Handles the tooltip from the right and left side Pokémon details bar.
- `TypeChartMixin`: Handles effectivity values when using Shadow moves, helping with the effectivity messages in some tooltips.