### PR TITLE
Fix two small visual bugs with Cobblemon Battle Extras

### DIFF
--- a/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/MixinBattleMoveSelectionMoveTile.java
+++ b/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/MixinBattleMoveSelectionMoveTile.java
@@ -71,8 +71,7 @@ public abstract class MixinBattleMoveSelectionMoveTile {
         BattleMoveSelection.MoveTile self = (BattleMoveSelection.MoveTile) (Object) this;
         InBattleMove m = self.getMove();
         var pokemon = self.getPokemon();
-        if (m.getDisabled() || ShadowGate.isShadowMoveId(m.getId()) && pokemon != null
-                && ShadowGate.isShadowLockedClient(pokemon)) {
+        if (ShadowGate.isShadowMoveId(m.getId()) && pokemon != null && ShadowGate.isShadowLockedClient(pokemon)) {
             return Component.literal("??/??").copy().withStyle(s -> s.withBold(true));
         }
         return original;

--- a/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtrasCustomBattleControllerMixin.java
+++ b/common/src/main/java/com/jayemceekay/shadowedhearts/mixin/cobblemonbattleextras/CobblemonBattleExtrasCustomBattleControllerMixin.java
@@ -209,25 +209,27 @@ public class CobblemonBattleExtrasCustomBattleControllerMixin {
     // Both "Object" are CategoryChipStyle.
     @WrapOperation(method = "renderCustomMoveTile", at = @At(value = "INVOKE", target = "Lname/modid/client/CustomBattleController;resolveMoveCategoryChipStyle(Ljava/lang/String;)Lname/modid/client/CustomBattleController$CategoryChipStyle;"))
     private static @Coerce Object shadowedhearts$resolveChipStyle(String categoryKey, Operation<Object> original) {
-        try {
-            Class<?> clazz = Class.forName("name.modid.client.CustomBattleController$CategoryChipStyle");
-            Constructor<?> ctor = clazz.getDeclaredConstructor(
-                    String.class, int.class, int.class, int.class, int.class, int.class
-            );
-            ctor.setAccessible(true);
+        if (categoryKey.equals("???")) {
+            try {
+                Class<?> clazz = Class.forName("name.modid.client.CustomBattleController$CategoryChipStyle");
+                Constructor<?> ctor = clazz.getDeclaredConstructor(
+                        String.class, int.class, int.class, int.class, int.class, int.class
+                );
+                ctor.setAccessible(true);
 
-            // Same values as STA, copied from resolveMoveCategoryChipStyle
-            return ctor.newInstance(
-                    "???", // label
-                    16, // width
-                    -8683114, // bgTop
-                    -11907231, // bgBottom
-                    -3814695, // border
-                    -1 // text
-            );
-        } catch (Throwable e) {
-            //throw new RuntimeException(e);
-            return original.call(categoryKey);
+                // Same values as STA, copied from resolveMoveCategoryChipStyle
+                return ctor.newInstance(
+                        "???", // label
+                        16, // width
+                        -8683114, // bgTop
+                        -11907231, // bgBottom
+                        -3814695, // border
+                        -1 // text
+                );
+            } catch (Throwable e) {
+                //throw new RuntimeException(e);
+            }
         }
+        return original.call(categoryKey);
     }
 }


### PR DESCRIPTION
Hi again,

I've just noticed two small visual bugs in the move buttons caused by the changes I made in the previous PR...

* One of them affected the new Custom Tiles, causing all attacks to appear with the category "???".
* The other affects the Classic Tiles, causing all disabled attacks (for example, attacks with 0/X PP) to appear with "??/??" PP.

I hope these are the last changes and bug fixes I have to push related to this 😅 haha

Thank you again!